### PR TITLE
Feature/fix popup content

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,8 +2,9 @@
 
 const allowedHosts = [
   'dev.moneymeets.net',
-  'my.moneymeets.com',
-  'moneymeets.services'
+  'beratung.dev',
+  'beratung.show',
+  'beratung.io'
 ];
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/src/content.js
+++ b/src/content.js
@@ -5,10 +5,15 @@ const MetaNameEnum = Object.freeze({
   MM_BRANCH: 'moneymeets:branch'
 });
 
-const metaElementVersionContent = getAttributeValue(document.querySelector(`meta[name="${MetaNameEnum.MM_VERSION}"]`), 'content') || '';
-const metaElementBranchContent =  getAttributeValue(document.querySelector(`meta[name="${MetaNameEnum.MM_BRANCH}"]`), 'content') || '';
+let metaElementVersionContent;
+let metaElementBranchContent;
 
-storeMetadata(metaElementVersionContent, metaElementBranchContent);
+const interval = setInterval(() => {
+  metaElementVersionContent = getAttributeValue(document.querySelector(`meta[name="${MetaNameEnum.MM_VERSION}"]`), 'content') || '';
+  metaElementBranchContent =  getAttributeValue(document.querySelector(`meta[name="${MetaNameEnum.MM_BRANCH}"]`), 'content') || '';
+  storeMetadata(metaElementVersionContent, metaElementBranchContent);
+  clearInterval(interval);
+}, 500);
 
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'visible') {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,8 +32,8 @@
     {
       "matches": [
         "https://*.moneymeets.net/*",
-        "https://my.moneymeets.com/*",
-        "https://*.moneymeets.services/*"
+        "https://*.beratung.io/*",
+        "https://*.beratung.show/*"
       ],
       "js": ["content.js"]
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,9 +31,10 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.moneymeets.net/*",
-        "https://*.beratung.io/*",
-        "https://*.beratung.show/*"
+        "https://*.dev.moneymeets.net/*",
+        "https://*.beratung.dev/*",
+        "https://*.beratung.show/*",
+        "https://*.beratung.io/*"
       ],
       "js": ["content.js"]
     }


### PR DESCRIPTION
Meta-Tags werden jetzt wieder korrekt gelesen.
Diese werden von der moneymeets-app dynamisch nach App-Start hinzugefügt. Das muss in der Extension berücksichtigt werden.

Ich habe zusätzlich die neuen Domains ergänzt. Allerdings scheint die Extension nicht für *.beratung.io und *.beratung.show nicht zu funktionieren.
Kannst du das bitte einmal testen. Gerne können wir das gemeinsam anschauen.