### PR TITLE
feat(github): add required permissions to rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,6 +12,9 @@ jobs:
     # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
     if: github.event.issue.pull_request && github.event.comment.body == '/rebase'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The merge-check workflows mergealot is triggering seem to be stuck in a queue and take too long finish, causing a timeout in Pulumi. 
![Screenshot 2023-06-15 at 09 18 26](https://github.com/moneymeets/moneymeets-browser-extension/assets/610633/2291f306-30b4-428a-a905-cd7349522a1f)


I'm adding the change for the rebase workflow (https://github.com/moneymeets/moneymeets-pulumi/pull/418) manually here and then import into our Pulumi state via `pulumi refresh`. Hopefully this is a one-time occurrence, if this keeps happening for large updates, we should understand better why this happens and come up with a solution.